### PR TITLE
Hide `pane_id` in the `fzf` pop-up window

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can override the following options in your `tmux.conf` file.
 set -g @fzf_pane_switch_bind-key "key binding"
 ```
 
-Default is `s`, which replaces the tmux default session select (tmux default: `choose-tree -Zs -O name`)
+Default is `prefix + s`, which replaces the tmux default session select (tmux default: `choose-tree -Zs -O name`)
 
 ### fzf window position
 
@@ -74,9 +74,9 @@ This is the output format of `tmux list-panes` that you see in the fzf window. Y
 set -g @fzf_pane_switch_list-panes-format "FORMATS"
 ```
 
-Default is `session_name window_name pane_title pane_current_command`.
+Default is `pane_id session_name window_name pane_title pane_current_command`.
 
-Note: The `list-panes` format will always start with `pane_id` as that what's passed into `switch-client` to allow switching on matched panes. You can use any tmux FORMAT options allowed [here](https://www.man7.org/linux/man-pages/man1/tmux.1.html#FORMATS).
+Note: You can use any tmux FORMAT option allowed [here](https://www.man7.org/linux/man-pages/man1/tmux.1.html#FORMATS). String manipulation should also work. For example, the `pane_id` by default is shown with a leading percent symbol (e.g. `%3`). You can remove this by setting `set -g @fzf_pane_switch_list-panes-format "s/%//:pane_id session_name window_name pane_title pane_current_command"`
 
 ## Demo Configuration
 

--- a/select_pane.sh
+++ b/select_pane.sh
@@ -14,12 +14,12 @@ function select_pane() {
     # Check if we're using the fzf preview pane
     if [[ "${1}" = 'true' ]]; then
         pane=$(tmux list-panes -aF "${4}" | 
-            awk '{$1=substr($1, 2); print}' | 
-            fzf --exit-0 --bind=enter:replace-query+print-query --reverse --tmux "${2}" --preview='tmux capture-pane -ep -t %{1}' --preview-label='pane preview' --preview-window="${3}")
+            fzf --exit-0 --print-query --reverse --tmux "${2}" --with-nth=2.. --preview='tmux capture-pane -ep -t {1}' --preview-label='pane preview' --preview-window="${3}" | 
+            tail -1)
     else
         pane=$(tmux list-panes -aF "${4}" | 
-            awk '{$1=substr($1, 2); print}' | 
-            fzf --exit-0 --bind=enter:replace-query+print-query --reverse --tmux "${2}")
+            fzf --exit-0 --print-query --reverse --tmux "${2}" --with-nth=2.. | 
+            tail -1)
     fi
 
     # Set pane_id to first part of fzf output
@@ -29,9 +29,9 @@ function select_pane() {
     if [[ -z "${pane_id}" ]]; then
         tmux switch-client -t "${current_pane}"
     # Check if pane exists
-    elif tmux has-session -t "%${pane_id}" >/dev/null 2>&1; then
+    elif tmux has-session -t "${pane_id}" >/dev/null 2>&1; then
         # Found it! Let's switch.
-        tmux switch-client -t "%${pane_id}"
+        tmux switch-client -t "${pane_id}"
     else
         # Pane not found, let's create it.
         tmux command-prompt -b -p "Press ENTER to create a new window in the current session [${pane}]" "new-window -n \"${pane}\""

--- a/select_pane.tmux
+++ b/select_pane.tmux
@@ -7,7 +7,7 @@ default_bind_key='s'
 default_preview_pane='true'
 default_fzf_window_position='center,70%,80%'
 default_fzf_preview_window_position='right,,,nowrap'
-default_tmux_list_panes_format='session_name window_name pane_title pane_current_command'
+default_tmux_list_panes_format='pane_id session_name window_name pane_title pane_current_command'
 
 # User overridable options
 tmux_bind_key="@fzf_pane_switch_bind-key"


### PR DESCRIPTION
This PR allows for the `pane_id` to be hidden in the `fzf` pop-up window, as requested in #4.

Originally, the `pane_id` was required to be in the first position of the returned output. While this is required, what's shown in the `fzf` window can be suppressed by passing the `--with-nth` option. To maintain the default output, the new default for `@fzf_pane_switch_list-panes-format` adds `pane_id` to the beginning of the format string.

String manipulation should also work. For example, the `pane_id` by default is shown with a leading percent symbol (e.g. `%3`). You can remove this by setting `set -g @fzf_pane_switch_list-panes-format "s/%//:pane_id session_name window_name pane_title pane_current_command"`. To remove the `pane_id` (or any other variable), simply drop it from the setting (e.g. `set -g @fzf_pane_switch_list-panes-format "session_name window_name pane_title pane_current_command"`